### PR TITLE
correction in readme getting started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@ To get started with AutoGroq, follow these steps:
 1. Install Autogen following Matt Berman's instructions:  https://www.youtube.com/watch?v=mUEFwUU0IfE
 2. Install Mini-conda:  https://docs.anaconda.com/free/miniconda/miniconda-install/
 3. Open a command prompt and run the following commands:
-   md c:\AutoGroq  
-   cd c:\AutoGroq  
-   conda create -n AutoGroq python=3.11  
-   conda activate AutoGroq  
-   git clone https://github.com/jgravelle/AutoGroq.git  
-   pip install -r requirements.txt  
-   streamlit run c:\AutoGroq\AutoGroq\main.py
+
+```winbatch
+conda create -n AutoGroq python=3.11
+conda activate AutoGroq
+git clone https://github.com/jgravelle/AutoGroq.git
+cd AutoGroq
+pip install -r requirements.txt
+streamlit run AutoGroq\main.py
+```
 
 ## Configuration
 


### PR DESCRIPTION
old instructions:

```winbatch
md c:\AutoGroq  
cd c:\AutoGroq  

# ... 

# following creates c:\AutoGroq\AutoGroq:
git clone https://github.com/jgravelle/AutoGroq.git

# (still in c:\AutoGroq)
pip install -r requirements.txt

# ^ pip install FAILS because we're in the wrong dir; we need to `cd AutoGroq` first
```